### PR TITLE
Redesign footer layout: reduce padding and move icons above copyright

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,7 +3,6 @@ const today = new Date();
 ---
 
 <footer>
-	&copy; {today.getFullYear()} ZEPHYR PRODUCTIONS LLC. All rights reserved.
 	<div class="social-links">
 		<a href="https://m.webtoo.ls/@astro" target="_blank">
 			<span class="sr-only">Join us on Discord</span>
@@ -38,10 +37,11 @@ const today = new Date();
 			>
 		</a>
 	</div>
+	&copy; {today.getFullYear()} ZEPHYR PRODUCTIONS LLC. All rights reserved.
 </footer>
 <style>
 	footer {
-		padding: 2em 1em 6em 1em;
+		padding: 1.25em 1em;
 		background: rgba(10, 10, 14, 0.6);
 		backdrop-filter: blur(10px);
 		border-top: 1px solid rgba(var(--gray), 0.18);
@@ -53,7 +53,7 @@ const today = new Date();
 		display: flex;
 		justify-content: center;
 		gap: 1em;
-		margin-top: 1em;
+		margin-bottom: 0.75em;
 	}
 	.social-links a {
 		text-decoration: none;


### PR DESCRIPTION
## Purpose
The user requested to make the footer slimmer and reposition the social media icons to appear above the copyright text for improved visual hierarchy.

## Code changes
- **Reduced footer padding**: Changed from `2em 1em 6em 1em` to `1.25em 1em` to create a slimmer footer
- **Reordered footer content**: Moved copyright text below the social links div in the HTML structure
- **Updated social links styling**: Changed `margin-top: 1em` to `margin-bottom: 0.75em` to provide appropriate spacing above the copyright textTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/90c3f653e6cc43f0a800c6d9e0fdbfff/orbit-zone)

👀 [Preview Link](https://90c3f653e6cc43f0a800c6d9e0fdbfff-orbit-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>90c3f653e6cc43f0a800c6d9e0fdbfff</projectId>-->
<!--<branchName>orbit-zone</branchName>-->